### PR TITLE
allow decoding for multiple mqp tags

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -50,17 +50,23 @@ func Decode(query map[string][]string, v interface{}) error {
 		}
 
 		var s []string
+		var tag string
 		var ok bool
 
-		fieldTag := getFieldTag(fTyp)
-		if s, ok = query[fieldTag]; !ok {
+		fieldTags := getFieldTags(fTyp)
+		for _, tag = range fieldTags {
+			if s, ok = query[tag]; ok {
+				break
+			}
+		}
+		if len(s) == 0 {
 			continue
 		}
 
 		fVal := newVal.Elem().Field(i)
 		err := decodeField(s, fVal)
 		if err != nil {
-			return newDecodeError(fmt.Sprintf("unable to decode value in field '%s'", fieldTag), fieldTag, err)
+			return newDecodeError(fmt.Sprintf("unable to decode value in field '%s'", tag), tag, err)
 		}
 	}
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -205,21 +205,6 @@ func TestDecode(t *testing.T) {
 			}(), true,
 		},
 
-		// reflect.DeepEqual does not like time.Time :(
-		/*
-			{
-				"Times", args{map[string][]string{"A": {time.Unix(1000, 1000).Format(time.RFC3339Nano)}, "B": {"1000"}, "C": {string(mustMarshal(time.Unix(1000, 1000).MarshalJSON()))}},
-					func() *struct{ A, B, C time.Time } {
-						s := struct{ A, B, C time.Time }{}
-						return &s
-					}()},
-				func() *struct{ A, B, C time.Time } {
-					s := struct{ A, B, C time.Time }{time.Unix(1000, 1000), time.Unix(1000, 0), time.Unix(1000, 1000)}
-					return &s
-				}(), false,
-			},
-		*/
-
 		{
 			"JsonTag", args{map[string][]string{"b": {"foobar"}},
 				func() *struct {
@@ -255,6 +240,26 @@ func TestDecode(t *testing.T) {
 			} {
 				s := struct {
 					A string `mqp:"b"`
+				}{"foobar"}
+				return &s
+			}(), false,
+		},
+
+		{
+			"MultipleMQPTag", args{map[string][]string{"c": {"foobar"}},
+				func() *struct {
+					A string `mqp:"b,c"`
+				} {
+					s := struct {
+						A string `mqp:"b,c"`
+					}{}
+					return &s
+				}()},
+			func() *struct {
+				A string `mqp:"b,c"`
+			} {
+				s := struct {
+					A string `mqp:"b,c"`
 				}{"foobar"}
 				return &s
 			}(), false,
@@ -325,8 +330,4 @@ func TestDecodeTime(t *testing.T) {
 			t.Errorf("testing %q: wanted %q, got %q", test, expected, actual.Time)
 		}
 	}
-}
-
-func mustMarshal(b []byte, _ error) []byte {
-	return b
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -47,7 +47,7 @@ func TestEncode(t *testing.T) {
 			A string `json:"b,omitempty"`
 		}{"foobar"}}, map[string][]string{"b": {"foobar"}}, false},
 		{"MQPTag", args{struct {
-			A string `json:"b" mqp:"c"`
+			A string `json:"b" mqp:"c,d"`
 		}{"foobar"}}, map[string][]string{"c": {"foobar"}}, false},
 		{"SkipChannels", args{struct{ Value chan string }{Value: make(chan string)}}, map[string][]string{}, false},
 		{"SkipFunctions", args{struct{ Value func() }{Value: func() {}}}, map[string][]string{}, false},


### PR DESCRIPTION
Allow the decoding logic to decode a struct field from multple possible MQP tags. The MQP tags format for multiple supported tags is comma separated, just like the json tag. 